### PR TITLE
Chore: Remove deprecated iAd framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,8 @@
 # react-native-apple-ads-attribution
 
-Fetches apple attribution data via iAd and AdServices APIs
+Fetches apple attribution data via AdServices API
 
 ## Requirements
-- iAd Framework
 - AdServices Framework
 
 ## Installation
@@ -18,7 +17,6 @@ npm install @nutrisense/react-native-apple-ads-attribution
 import AppleAdsAttribution from "@nutrisense/react-native-apple-ads-attribution";
 
 const attributionData = await AppleAdsAttribution.getAttributionData();
-const iAdAttributionData = await AppleAdsAttribution.getiAdAttributionData();
 const adServicesAttributionToken = await AppleAdsAttribution.getAdServicesAttributionToken();
 const adServicesAttributionData = await AppleAdsAttribution.getAdServicesAttributionData();
 ```
@@ -28,46 +26,6 @@ Note from version 1.0 the above functions propagates errors, so they should be w
 
 #### getAttributionData()
 Gets install attribution data first trying to use the AdServices API (iOS 14.3+).  
-If it fails to retrieve data it will fallback to iAd API.
-Throws error if everything fails
-
-#### getiAdAttributionData()
-Gets install attribution data using iAd API https://developer.apple.com/documentation/iad/setting_up_apple_search_ads_attribution/  
-Throws error if data couldn't be retrieved (e.g. if user rejected permission for app tracking)
-
-##### Example
-```javascript
-try {
-  const iAdAttributionData = await AppleAdsAttribution.getiAdAttributionData()
-  console.log(iAdAttributionData) // -->
-    // {
-    //   "Version3.1": {
-    //     "iad-lineitem-name": "LineName",
-    //     "iad-attribution": "true",
-    //     "iad-campaign-name": "CampaignName",
-    //     "iad-org-name": "OrgName",
-    //     "iad-conversion-type": "Download",
-    //     "iad-org-id": "1234567890",
-    //     "iad-campaign-id": "1234567890",
-    //     "iad-adgroup-name": "AdGroupName",
-    //     "iad-country-or-region": "US",
-    //     "iad-creativeset-name": "CreativeSetName",
-    //     "iad-keyword-matchtype": "Broad",
-    //     "iad-conversion-date": "2021-04-07T12:14:04Z",
-    //     "iad-creativeset-id": "1234567890",
-    //     "iad-keyword-id": "12323222",
-    //     "iad-lineitem-id": "1234567890",
-    //     "iad-click-date": "2021-04-07T12:14:04Z",
-    //     "iad-purchase-date": "2021-04-07T12:14:04Z",
-    //     "iad-adgroup-id": "1234567890",
-    //     "iad-keyword": "Keyword"
-    //   }
-    // }
-} catch (error) {
-  const { message } = error
-  console.log(message) // --> Some error message
-}
-```
 
 #### getAdServicesAttributionToken()
 Generates a AdServices token valid for 24 hours that then can be used to request attribution data from Apples AdServices API, see https://developer.apple.com/documentation/adservices  

--- a/index.js
+++ b/index.js
@@ -11,13 +11,6 @@ class AppleAdsAttribution {
     return RNAppleAdsAttribution.getAttributionData();
   }
 
-  getiAdAttributionData() {
-    if (Platform.OS !== 'ios') {
-      return null
-    }
-    return RNAppleAdsAttribution.getiAdAttributionData();
-  }
-
   getAdServicesAttributionToken() {
     if (Platform.OS !== 'ios') {
       return null

--- a/ios/AppleAdsAttribution.m
+++ b/ios/AppleAdsAttribution.m
@@ -1,7 +1,6 @@
 #import "AppleAdsAttribution.h"
 #import <React/RCTLog.h>
 #import <AdServices/AdServices.h>
-#import <iAd/iAd.h>
 
 @implementation AppleAdsAttribution
 static NSString *const RNAAAErrorDomain = @"RNAAAErrorDomain";
@@ -182,32 +181,7 @@ API_AVAILABLE(ios(14.3)) {
 }
 
 /**
- * Gets attribution data from the old iAd API.
- * completionHandler will return nil with an error if attribution data couldn't be retrieved. Reasons for failing may be that the user disabled tracking or that the iOS version is < 10.
- */
-+ (void) getiAdAttributionDataWithCompletionHandler: (void (^)(NSDictionary * _Nullable data, NSError * _Nullable error))completionHandler {
-
-    if ([[ADClient sharedClient] respondsToSelector:@selector(requestAttributionDetailsWithBlock:)]) {
-        [[ADClient sharedClient] requestAttributionDetailsWithBlock: ^(NSDictionary *attributionDetails, NSError *error) {
-            if (error == nil) {
-                completionHandler(attributionDetails, nil);
-            } else {
-                NSLog(@"getiAdAttributionDataWithCompletionHandler error getting data %@", error);
-                completionHandler(nil, error);
-            }
-        }];
-    } else {
-        // requestAttributionDetailsWithBlock is not available probably < iOS 10
-        NSMutableDictionary* details = [NSMutableDictionary dictionary];
-        [details setValue:@"iAd ADClient not available" forKey:NSLocalizedDescriptionKey];
-        NSError* error = [NSError errorWithDomain:RNAAAErrorDomain code:100 userInfo:details];
-        completionHandler(nil, error);
-    }
-}
-
-/**
- * Tries to get attribution data first using the AdServices API. If it fails it fallbacks to the old iAd API.
- * Rejected with error if both fails
+ * Tries to get attribution data first using the AdServices API.
  */
 RCT_EXPORT_METHOD(getAttributionData:
                   (RCTPromiseResolveBlock) resolve
@@ -218,39 +192,9 @@ RCT_EXPORT_METHOD(getAttributionData:
         if (attributionData != nil) {
             resolve(attributionData);
         } else {
-            // Fallback to old iAd client API
-            [AppleAdsAttribution getiAdAttributionDataWithCompletionHandler:^(NSDictionary * _Nullable data, NSError * _Nullable iAdError) {
-                if (data != nil) {
-                    resolve(data);
-                } else {
-                    // Reject with both error messages
-                    NSString *combinedErrorMessage = [NSString stringWithFormat:@"Ad services error: %@. \niAD error: %@", adServicesError != NULL ? adServicesError.localizedDescription : @"no error message", iAdError != NULL ? iAdError.localizedDescription : @"no error message"];
-
-                    [AppleAdsAttribution rejectPromiseWithUserInfo:reject
-                                                          userInfo:[@{
-                                                            @"code" : @"unknown",
-                                                            @"message" : combinedErrorMessage
-                                                          } mutableCopy]];
-                }
-
-            }];
+            // No longer falling back to iAd, just reject with AdServices error
+            [AppleAdsAttribution rejectPromiseWithNSError:reject error:adServicesError];
         }
-    }];
-}
-
-/**
- * Tries to get attribution data using the old iAd API.
- * Rejected with error if it failed to get data
- *  */
-RCT_EXPORT_METHOD(getiAdAttributionData: (RCTPromiseResolveBlock) resolve rejecter: (RCTPromiseRejectBlock) reject) {
-
-    [AppleAdsAttribution getiAdAttributionDataWithCompletionHandler:^(NSDictionary * _Nullable data, NSError * _Nullable error) {
-        if(data != nil) {
-            resolve(data);
-        } else {
-            [AppleAdsAttribution rejectPromiseWithNSError:reject error:error];
-        }
-
     }];
 }
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@nutrisense/react-native-apple-ads-attribution",
   "version": "1.0.2",
-  "description": "Fetches apple attribution data via iAd and AdServices APIs",
+  "description": "Fetches Apple attribution data via AdServices APIs",
   "main": "index",
   "scripts": {
     "release": "release-it"
@@ -12,7 +12,6 @@
     "apple",
     "ads",
     "search-ads",
-    "iAd",
     "AdServices",
     "attribution",
     "attributionDetails",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nutrisense/react-native-apple-ads-attribution",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Fetches Apple attribution data via AdServices APIs",
   "main": "index",
   "scripts": {

--- a/react-native-apple-ads-attribution.podspec
+++ b/react-native-apple-ads-attribution.podspec
@@ -11,7 +11,7 @@ Pod::Spec.new do |s|
   s.authors      = package["author"]
 
   s.platforms    = { :ios => "10.0" }
-  s.ios.weak_framework = 'iAd', 'AdServices'
+  s.ios.weak_framework = 'AdServices'
   s.source       = { :git => "https://github.com/joel-bitar/react-native-apple-ads-attribution.git", :tag => "#{s.version}" }
 
   s.source_files = "ios/**/*.{h,m,mm}"


### PR DESCRIPTION
A build was failing in Xcode 16.2 with `Undefined symbol: _OBJC_CLASS_$_ADClient` 

Turns out iAd framework is deprecated and makes the build fail. Removing it fixes the issue.

Similar solution in StackOverflow - https://stackoverflow.com/a/78994085